### PR TITLE
fix /tmp/env copy statement

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -102,7 +102,7 @@ export STACK=cedar-14
 ## copy the environment dir excluding the ephemeral ..data/ dir and other symlinks created by Kubernetes.
 
 if [ "$(ls -A $secret_dir)" ]; then
-   cp $secret_dir/* $env_root/
+   cp -r $secret_dir/. $env_root/
 fi
 
 ## SSH key configuration


### PR DESCRIPTION
Fixes https://github.com/teamhephy/builder/issues/47
Fixes https://github.com/teamhephy/builder/issues/4

The bug was that ls -A lists dotfiles, but the `*` doesn't include them.