### PR TITLE
feat(slugbuilder): Add DEIS_BUILDPACK_DEBUG variable to show more or less output when deploying

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -157,7 +157,12 @@ if [[ -n "$BUILDPACK_URL" ]]; then
     buildpack_name=$("$buildpack/bin/detect" "$build_root") && selected_buildpack=$buildpack
 else
     for buildpack in "${buildpacks[@]}"; do
-        buildpack_name=$("$buildpack/bin/detect" "$build_root") && selected_buildpack=$buildpack && break
+        shopt -s nocasematch
+        if [[ "$DEIS_BUILDPACK_DEBUG" == "True" ]]; then
+            buildpack_name=$("$buildpack/bin/detect" "$build_root") && selected_buildpack=$buildpack && break
+        else
+            buildpack_name=$("$buildpack/bin/detect" "$build_root" 2> /dev/null) && selected_buildpack=$buildpack && break
+        fi
     done
 fi
 


### PR DESCRIPTION
refs teamhephy/workflow#109
refs teamhephy/builder#54

This checks if variable `DEIS_BUILDPACK_DEBUG` is set to True. If so, then buildpacks will show its respective "failed to detect" errors.