### PR TITLE
Object-storage-cli updates

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -30,7 +30,7 @@ RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
 
 ADD . /
 ENV PYTHONPATH $PYTHONPATH:/usr/local/lib/python3/site-packages
-ADD https://storage.googleapis.com/object-storage-cli/bb209cb/objstorage-bb209cb-linux-amd64 /bin/objstorage
+ADD https://storage.googleapis.com/hephy-obj-storage-cli/bb8e054/objstorage /bin/objstorage
 RUN chmod +x /bin/objstorage && \
     chown -R slug:slug /app && \
     chown slug:slug /bin/get_object \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -30,8 +30,8 @@ RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
 
 ADD . /
 ENV PYTHONPATH $PYTHONPATH:/usr/local/lib/python3/site-packages
-RUN mv objstorage /bin/objstorage && \
-    chmod +x /bin/objstorage && \
+ADD https://storage.googleapis.com/object-storage-cli/bb8e054/objstorage-bb8e054-linux-amd64 /bin/objstorage
+RUN chmod +x /bin/objstorage && \
     chown -R slug:slug /app && \
     chown slug:slug /bin/get_object \
                     /bin/normalize_storage \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -30,7 +30,7 @@ RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
 
 ADD . /
 ENV PYTHONPATH $PYTHONPATH:/usr/local/lib/python3/site-packages
-ADD https://storage.googleapis.com/object-storage-cli/bb8e054/objstorage-bb8e054-linux-amd64 /bin/objstorage
+ADD https://storage.googleapis.com/object-storage-cli/bb209cb/objstorage-bb209cb-linux-amd64 /bin/objstorage
 RUN chmod +x /bin/objstorage && \
     chown -R slug:slug /app && \
     chown slug:slug /bin/get_object \

--- a/rootfs/builder/install-buildpacks
+++ b/rootfs/builder/install-buildpacks
@@ -29,14 +29,14 @@ download_buildpack() {
 mkdir -p $BUILDPACK_INSTALL_PATH
 
 download_buildpack https://github.com/heroku/heroku-buildpack-multi.git          v1.0.0   01-multi
-download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v84      02-clojure
+download_buildpack https://github.com/heroku/heroku-buildpack-clojure.git        v85      02-clojure
 download_buildpack https://github.com/heroku/heroku-buildpack-go.git             v140     03-go
 download_buildpack https://github.com/heroku/heroku-buildpack-gradle.git         v31      04-gradle
 download_buildpack https://github.com/heroku/heroku-buildpack-grails.git         v21      05-grails
 download_buildpack https://github.com/heroku/heroku-buildpack-java.git           v66      06-java
-download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v171     07-nodejs
-download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v174     08-php
+download_buildpack https://github.com/heroku/heroku-buildpack-nodejs.git         v176     07-nodejs
+download_buildpack https://github.com/heroku/heroku-buildpack-php.git            v181     08-php
 download_buildpack https://github.com/heroku/heroku-buildpack-play.git           v26      09-play
-download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v170     10-python
-download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v215     11-ruby
+download_buildpack https://github.com/heroku/heroku-buildpack-python.git         v181     10-python
+download_buildpack https://github.com/heroku/heroku-buildpack-ruby.git           v218     11-ruby
 download_buildpack https://github.com/heroku/heroku-buildpack-scala.git          v87      12-scala


### PR DESCRIPTION
Testing this build from kingdonb/slugbuilder:git-0aaaf09

It looks like we had worked around this object-storage-cli issue before by placing a binary in the repo, this PR undoes that.

This is the same change from teamhephy/slugrunner#9, updated build of object-storage-cli