### PR TITLE
fix(build.sh): Quotes on variable causes build detect to break

### DIFF
--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -122,7 +122,8 @@ fi
 
 ## Buildpack detection
 
-buildpacks=("$buildpack_root/*")
+# shellcheck disable=SC2206
+buildpacks=(${buildpack_root/*})
 selected_buildpack=
 
 if [[ -n "$BUILDPACK_URL" ]]; then


### PR DESCRIPTION
```
$ git push deis master
Enumerating objects: 964, done.
Counting objects: 100% (964/964), done.
Delta compression using up to 8 threads
Compressing objects: 100% (601/601), done.
Writing objects: 100% (964/964), 177.31 KiB | 10.43 MiB/s, done.
Total 964 (delta 576), reused 573 (delta 340), pack-reused 0
remote: Resolving deltas: 100% (576/576), done.
Starting build... but first, coffee!
...
...
-----> Restoring cache...
       No cache file found. If this is the first deploy, it will be created now.
/builder/build.sh: line 162: /tmp/buildpacks/*/bin/detect: No such file or directory
-----> Unable to select a buildpack
```


```
slug@78a0f0b805eb:~$ buildpacks=($buildpack_root/*)
slug@78a0f0b805eb:~$ for buildpack in "${buildpacks[@]}"; do   echo "- $buildpack"; done
- /tmp/buildpacks/01-multi
- /tmp/buildpacks/02-clojure
- /tmp/buildpacks/03-go
- /tmp/buildpacks/04-gradle
- /tmp/buildpacks/05-grails
- /tmp/buildpacks/06-java
- /tmp/buildpacks/07-nodejs
- /tmp/buildpacks/08-php
- /tmp/buildpacks/09-play
- /tmp/buildpacks/10-python
- /tmp/buildpacks/11-ruby
- /tmp/buildpacks/12-scala


slug@78a0f0b805eb:~$ buildpacks=("$buildpack_root/*")
slug@78a0f0b805eb:~$ for buildpack in "${buildpacks[@]}"; do   echo "- $buildpack"; done
- /tmp/buildpacks/*
slug@78a0f0b805eb:~$
```